### PR TITLE
fix: apply PR #79 review findings to hq-bot command registration

### DIFF
--- a/services/hq/bot/src/lib.rs
+++ b/services/hq/bot/src/lib.rs
@@ -127,6 +127,7 @@ pub async fn run(
                 commands::music::skip(),
                 commands::music::volume(),
                 commands::music::wedding(),
+                commands::music::resurrection(),
                 commands::queue::queue(),
                 commands::queue::clear(),
                 commands::queue::enqueue(),


### PR DESCRIPTION
## Stacked on #79

This PR stacks on top of #79 ("feat: add recurrection", head `316f6d4`). Because #79's head branch lives in the author's fork and GitHub stacked PRs require same-repo branches, `316f6d4` is mirrored here as `pr79-mirror` and this PR targets that branch. **Merge order: #79 first, then this PR (retarget to `main` after #79 lands).**

Diff shown = only this PR's changes on top of #79.

## What this addresses

Follow-up to the review of #79 (blocker). Registers the new `/부활` (resurrection) command in the bot's command list in `services/hq/bot/src/lib.rs`:

- The `resurrection` command was defined in `services/hq/bot/src/commands/music.rs` but never added to `FrameworkOptions.commands`, so it was dead code — Discord never received the `/부활` slash command and the handler was unreachable.
- Added `commands::music::resurrection(),` next to `commands::music::wedding(),`, so the command is registered globally in `.setup()` like every other music command.

## Verification

- `cargo check -p hq-bot` — clean (exit 0)
- `cargo fmt --all -- --check` — no diffs in `music.rs`; the two pre-existing `lib.rs` hunks (import order, long `tracing::error!` line) are unrelated to this change and left untouched.

## Open note

Per review item #2: the audio request alias `"r"` is resolved by the `wedding` tap itself (tap config lives in the DB, not the repo), so it could not be verified from source. If the alias doesn't exist on the tap, the play call will fail at runtime with the tap's own error — worth confirming before the underlying #79 merges.
