### PR TITLE
fix: recover taphub transport from wedged pooled connections

### DIFF
--- a/crates/taphub-transport/client/src/lib.rs
+++ b/crates/taphub-transport/client/src/lib.rs
@@ -109,11 +109,10 @@ impl TransportClient {
     /// One request/response exchange with a per-attempt timeout, isolated to a single
     /// pooled connection so a failure here never disturbs sibling requests on the other
     /// pooled connections. Recovery is scoped:
-    /// - **Timeout**: the request's own QUIC stream is already dropped when the future is
-    ///   cancelled; we do NOT reset the connection (that would tear down unrelated
-    ///   in-flight requests sharing it). We just retry on a fresh stream. Genuinely dead
-    ///   connections are caught by keepalive + `ReconnectingClient`'s auto-reconnect on
-    ///   the next `open_chan`.
+    /// - **Timeout**: the request's own QUIC stream is dropped when the future is
+    ///   cancelled, and we reset *this* pooled connection before retrying so a wedged
+    ///   connection (one that accepts the channel but never answers) is evicted from
+    ///   the pool instead of being reused forever. Sibling connections are untouched.
     /// - **Transport error**: reset only *this* pooled connection, then retry.
     ///
     /// Application-level `TapHubResponse::Error` is returned as-is, never retried.
@@ -149,8 +148,12 @@ impl TransportClient {
                     tracing::warn!(
                         timeout_ms = self.request_timeout.as_millis() as u64,
                         attempt,
-                        "taphub request timed out; retrying on a fresh stream (connection left intact)"
+                        "taphub request timed out; resetting this pooled connection and retrying"
                     );
+                    // A connection that accepts a channel but never answers is wedged;
+                    // leaving it intact (as before) kept routing requests to a dead
+                    // connection forever. Reset it so the retry lands on a fresh one.
+                    conn.reset(RESET_CLOSE_CODE).await;
                 }
                 Err(_) => {
                     return Err(TapHubError::Internal(format!(

--- a/helm/templates/services/audio-engine.yaml
+++ b/helm/templates/services/audio-engine.yaml
@@ -79,7 +79,7 @@ spec:
             - name: TAPHUB_TRANSPORT_CERT_FILE
               value: "/certs/transport/{{ .Values.taphub.transportTlsCaFilename }}"
             - name: TAPHUB_REQUEST_TIMEOUT_MS
-              value: "6000"
+              value: {{ .Values.audioEngine.requestTimeoutMs | default "13000" | quote }}
             - name: OTLP_ENDPOINT
               value: {{ include "zako3.otlpEndpoint" . | quote }}
             {{- include "zako3.otlpAuthEnv" . | nindent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -133,6 +133,10 @@ audioEngine:
     name: ""
     discordTokenKey: "discord-token"
     aeTokenKey: "ae-token"
+  # Per-attempt request timeout for AE → taphub transport calls (ms). Must be
+  # >= taphub.requestTimeoutMs (13s) or the AE gives up on requests the hub
+  # would still answer, making every slow tap look like a stall.
+  requestTimeoutMs: "13000"
 
 # --- Traffic Light ---
 trafficLight:

--- a/libs/zakofish/src/config.rs
+++ b/libs/zakofish/src/config.rs
@@ -26,15 +26,14 @@ pub fn load_private_key<P: AsRef<Path>>(path: P) -> Result<PrivateKeyDer<'static
     Ok(key)
 }
 
-/// Default protofish3 `ProtofishConfig` for zakofish. Disables the keepalive
-/// timeout; other pf3-specific knobs (max_datagram_size, retransmission buffer,
-/// credit batching, ack interval) keep their pf3 library defaults.
+/// Default protofish3 `ProtofishConfig` for zakofish. Keeps pf3's library
+/// defaults (keepalive_interval=15s, keepalive_timeout=45s) so dead tap
+/// connections are detected and reconnected within ~45s instead of lingering
+/// until quinn's idle timeout. Other pf3-specific knobs (max_datagram_size,
+/// retransmission buffer, credit batching, ack interval) keep their pf3
+/// library defaults.
 pub fn default_protofish3_config() -> protofish3::ProtofishConfig {
-    let mut cfg = protofish3::ProtofishConfig::default();
-
-    cfg.keepalive_timeout = None;
-
-    cfg
+    protofish3::ProtofishConfig::default()
 }
 
 /// Creates a pf3 `ServerConfig`. Loads the cert chain and private key from disk,

--- a/services/taphub/core/src/infra/hq.rs
+++ b/services/taphub/core/src/infra/hq.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
+use std::time::Duration;
 use zako3_types::{
     ZakoError, ZakoResult,
     hq::{DiscordUserId, Tap, User, rpc::HqRpcClient},
@@ -22,6 +23,10 @@ impl RpcHqRepository {
 
         let http_client = HttpClientBuilder::default()
             .set_headers(headers)
+            // Explicit cap (default is 60s) so a stalled HQ never holds a tap
+            // request hostage; a slow HQ call fails fast and the request errors
+            // instead of piling up behind the jsonrpsee default timeout.
+            .request_timeout(Duration::from_secs(5))
             .build(url)
             .map_err(|e| ZakoError::Rpc(e.to_string()))?;
 


### PR DESCRIPTION
## What

Durable fixes for the 2026-08-07 taphub stall (see attached diagnosis). The immediate rescue (`kubectl rollout restart deploy/zako3-taphub`) already revived the service; this PR prevents recurrence.

1. **taphub-transport client: reset pooled connection on timeout** (`crates/taphub-transport/client/src/lib.rs`)
   A connection that accepts a channel but never answers is wedged. The old code left it intact, so every request routed to it failed with a permanent 6s×2 timeout. Now we `conn.reset(RESET_CLOSE_CODE)` before retrying, evicting the dead connection from the pool (siblings untouched).

2. **AE→taphub timeout 6000 → 13000 ms** (`helm/`, values-driven `audioEngine.requestTimeoutMs`)
   The AE gave up 7s before taphub's own 13s request timeout, making every slow tap look like a full stall.

3. **tap SDK keepalive restored** (`libs/zakofish/src/config.rs`)
   pf3 default `keepalive_timeout=45s` was overridden to `None`, so dead tap connections lingered until quinn's idle timeout — delaying reconnects and repeating the DriverGone drop cycle. Back to the library default.

4. **taphub→HQ RPC explicit 5s timeout** (`services/taphub/core/src/infra/hq.rs`)
   jsonrpsee's default is 60s; a stalled HQ now fails fast instead of holding tap requests hostage.

## Verified

- `cargo check -p zako3-taphub-transport-client -p zakofish -p zako3-taphub-core` — clean
- `helm lint ./helm` — clean
- Rescue verified live: taphub restarted 17:47:53Z, all 10 taps re-authenticated, requests served since 17:50:09Z (~200ms), AE timeouts stopped

## Deploy

Merge → GH Actions builds images (`latest`) + chart (`0.1.0-latest`) → Flux reconciles. Note: code-only changes don't change chart manifests, so a manual `kubectl rollout restart deploy/zako3-taphub` (and the AE statefulset) is still needed to pick up new images — same as the existing habit.