### PR TITLE
fix(zakofish): re-enable QUIC idle timeout on server side

### DIFF
--- a/libs/zakofish/src/config.rs
+++ b/libs/zakofish/src/config.rs
@@ -49,7 +49,6 @@ pub fn create_server_config<P1: AsRef<Path>, P2: AsRef<Path>>(
 
     let mut cfg = protofish3::ServerConfig::new(bind_address, cert_chain, private_key);
     cfg.protofish = default_protofish3_config();
-    cfg.protofish.keepalive_timeout = None;
 
     Ok(cfg)
 }


### PR DESCRIPTION
Completes the keepalive fix for the tap↔taphub connection.

`create_server_config` still overrode `keepalive_timeout = None`, re-disabling quinn's `max_idle_timeout` on the taphub tap listener even after `default_protofish3_config` was fixed to keep the 45s default. Removed the leftover override so the server inherits the 45s keepalive_timeout and stale tap↔taphub connections are detected and torn down instead of lingering (which caused the 13s audio delay observed in prod).

Verified: `cargo build -p zakofish -p zako3-taphub-core -p zako3-tap-sdk -p zako3-taphub-transport-client -p zako3-taphub-transport-server` all pass.