### PR TITLE
feat(traffic-light): resilient TL client (pool reset) + immutable image tags

### DIFF
--- a/crates/tl-client/src/lib.rs
+++ b/crates/tl-client/src/lib.rs
@@ -1,6 +1,11 @@
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context as _, Result};
+use jsonrpsee::core::client::Error as RpcClientError;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use opentelemetry::global;
 use thiserror::Error;
@@ -8,10 +13,12 @@ use tl_protocol::{
     AudioEngineCommand, AudioEngineCommandRequest, AudioEngineCommandResponse, AudioEngineError,
     AudioEngineSessionCommand, AudioPlayRequest, SessionInfo, TrafficLightRpcClient,
 };
+use tokio::sync::RwLock;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use zako3_types::{
     AudioRequestString, AudioStopFilter, ChannelId, GuildId, QueueName, SessionState, TrackId,
-    Volume, hq::{DiscordUserId, TapId},
+    Volume,
+    hq::{DiscordUserId, TapId},
 };
 
 #[derive(Debug, Error)]
@@ -29,20 +36,85 @@ pub enum TlClientError {
 }
 
 pub struct TlClient {
-    client: HttpClient,
+    url: Arc<str>,
+    /// The jsonrpsee HttpClient keeps an internal keep-alive connection pool. A
+    /// pooled connection can go stale when the TL server restarts: reusing it
+    /// then fails permanently. We rebuild the client (fresh pool) on a
+    /// transport-level failure and retry once — mirroring the taphub-stall-
+    /// recovery pattern.
+    client: Arc<RwLock<HttpClient>>,
 }
 
 impl TlClient {
     /// Connect to a TL instance at `url` (e.g. `"http://127.0.0.1:7070"`).
     pub async fn connect(url: &str) -> Result<Self> {
-        let client = HttpClientBuilder::default()
-            .build(url)
-            .with_context(|| format!("failed to build TL client for {url}"))?;
-        Ok(Self { client })
+        let client =
+            Self::build(url).with_context(|| format!("failed to build TL client for {url}"))?;
+        Ok(Self {
+            url: Arc::from(url),
+            client: Arc::new(RwLock::new(client)),
+        })
     }
 
-    fn map_err(e: jsonrpsee::core::client::Error) -> TlClientError {
+    fn build(url: &str) -> Result<HttpClient> {
+        // Fail fast instead of jsonrpsee's default 60s when a pooled connection
+        // is wedged, so a dead TL is noticed quickly rather than stalling callers.
+        HttpClientBuilder::default()
+            .request_timeout(Duration::from_secs(10))
+            .build(url)
+            .map_err(Into::into)
+    }
+
+    fn map_err(e: RpcClientError) -> TlClientError {
         TlClientError::Transport(anyhow::anyhow!("{e}"))
+    }
+
+    /// Run one RPC round-trip. On a transport-level error (the telltale of a
+    /// stale keep-alive pooled connection after a server restart) we rebuild the
+    /// client — which resets the pool — and retry once. Application-level
+    /// (JSON-RPC call) errors are returned as-is and never retried.
+    async fn round_trip<T>(
+        &self,
+        op: impl for<'a> Fn(
+            &'a HttpClient,
+        )
+            -> Pin<Box<dyn Future<Output = Result<T, RpcClientError>> + Send + 'a>>,
+    ) -> Result<T, TlClientError> {
+        // First attempt on the current pooled client.
+        {
+            let client = self.client.read().await;
+            match op(&client).await {
+                Ok(v) => return Ok(v),
+                Err(e) if Self::is_transport(&e) => {
+                    tracing::warn!(
+                        "TL RPC transport error; rebuilding client and retrying once: {e}"
+                    );
+                }
+                Err(e) => return Err(Self::map_err(e)),
+            }
+        }
+
+        // Rebuild a fresh client (fresh connection pool) and retry once.
+        let fresh = match Self::build(&self.url) {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(TlClientError::Transport(anyhow::anyhow!(
+                    "failed to rebuild TL client: {e:#}"
+                )));
+            }
+        };
+        *self.client.write().await = fresh;
+        let client = self.client.read().await;
+        op(&client).await.map_err(Self::map_err)
+    }
+
+    fn is_transport(e: &RpcClientError) -> bool {
+        matches!(
+            e,
+            RpcClientError::Transport(_)
+                | RpcClientError::RestartNeeded(_)
+                | RpcClientError::RequestTimeout
+        )
     }
 
     fn ok_or_err(resp: AudioEngineCommandResponse) -> Result<(), TlClientError> {
@@ -88,19 +160,31 @@ impl TlClient {
         }
     }
 
-    pub async fn join(&self, guild_id: GuildId, channel_id: ChannelId) -> Result<(), TlClientError> {
+    pub async fn join(
+        &self,
+        guild_id: GuildId,
+        channel_id: ChannelId,
+    ) -> Result<(), TlClientError> {
         let req = Self::build_req(guild_id, channel_id, AudioEngineCommand::Join);
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
-    pub async fn leave(&self, guild_id: GuildId, channel_id: ChannelId) -> Result<(), TlClientError> {
+    pub async fn leave(
+        &self,
+        guild_id: GuildId,
+        channel_id: ChannelId,
+    ) -> Result<(), TlClientError> {
         let req = Self::build_req(
             guild_id,
             channel_id,
             AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::Leave),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -117,23 +201,23 @@ impl TlClient {
         let req = Self::build_req(
             guild_id,
             channel_id,
-            AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::Play(
-                AudioPlayRequest {
-                    queue_name,
-                    tap_id,
-                    ars,
-                    volume,
-                    initiator,
-                    headers: {
-                        let mut h = HashMap::new();
-                        let cx = tracing::Span::current().context();
-                        global::get_text_map_propagator(|p| p.inject_context(&cx, &mut h));
-                        h
-                    },
+            AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::Play(AudioPlayRequest {
+                queue_name,
+                tap_id,
+                ars,
+                volume,
+                initiator,
+                headers: {
+                    let mut h = HashMap::new();
+                    let cx = tracing::Span::current().context();
+                    global::get_text_map_propagator(|p| p.inject_context(&cx, &mut h));
+                    h
                 },
-            )),
+            })),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -148,7 +232,9 @@ impl TlClient {
             channel_id,
             AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::Stop(track_id)),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -163,7 +249,9 @@ impl TlClient {
             channel_id,
             AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::StopMany(filter)),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -177,7 +265,9 @@ impl TlClient {
             channel_id,
             AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::NextMusic),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -192,7 +282,9 @@ impl TlClient {
             channel_id,
             AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::Pause(queue_name)),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -207,7 +299,9 @@ impl TlClient {
             channel_id,
             AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::Resume(queue_name)),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -226,7 +320,9 @@ impl TlClient {
                 volume,
             }),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         Self::ok_or_err(resp)
     }
 
@@ -234,17 +330,12 @@ impl TlClient {
         &self,
         guild_id: GuildId,
     ) -> Result<Vec<SessionState>, TlClientError> {
-        self.client
-            .get_sessions_in_guild(guild_id)
+        self.round_trip(|c| Box::pin(c.get_sessions_in_guild(guild_id)))
             .await
-            .map_err(Self::map_err)
     }
 
     pub async fn list_bot_ids(&self) -> Result<Vec<String>, TlClientError> {
-        self.client
-            .list_bot_ids()
-            .await
-            .map_err(Self::map_err)
+        self.round_trip(|c| Box::pin(c.list_bot_ids())).await
     }
 
     pub async fn report_guilds(
@@ -252,24 +343,22 @@ impl TlClient {
         token: String,
         guilds: Vec<GuildId>,
     ) -> Result<(), TlClientError> {
-        self.client
-            .report_guilds(token, guilds)
+        self.round_trip(|c| Box::pin(c.report_guilds(token.clone(), guilds.clone())))
             .await
-            .map_err(Self::map_err)
     }
 
     pub async fn register_ae(&self, listen_addr: String) -> Result<String, TlClientError> {
-        self.client
-            .register_ae(listen_addr)
+        self.round_trip(|c| Box::pin(c.register_ae(listen_addr.clone())))
             .await
-            .map_err(Self::map_err)
     }
 
-    pub async fn heartbeat_ae(&self, token: String, listen_addr: String) -> Result<(), TlClientError> {
-        self.client
-            .heartbeat_ae(token, listen_addr)
+    pub async fn heartbeat_ae(
+        &self,
+        token: String,
+        listen_addr: String,
+    ) -> Result<(), TlClientError> {
+        self.round_trip(|c| Box::pin(c.heartbeat_ae(token.clone(), listen_addr.clone())))
             .await
-            .map_err(Self::map_err)
     }
 
     pub async fn get_session_state(
@@ -282,7 +371,9 @@ impl TlClient {
             channel_id,
             AudioEngineCommand::SessionCommand(AudioEngineSessionCommand::GetSessionState),
         );
-        let resp = self.client.execute(req).await.map_err(Self::map_err)?;
+        let resp = self
+            .round_trip(|c| Box::pin(c.execute(req.clone())))
+            .await?;
         match resp {
             AudioEngineCommandResponse::SessionState(s) => Ok(s),
             AudioEngineCommandResponse::Error(AudioEngineError::AlreadyJoined) => {

--- a/helm/deployment.md
+++ b/helm/deployment.md
@@ -11,6 +11,26 @@ image:
   pullPolicy: IfNotPresent
 ```
 
+### Pin an immutable tag for production
+
+`.github/workflows/docker-publish.yml` publishes two tags for every `main`
+build: `latest` and a **short-SHA immutable tag** (e.g. `a1b2c3d`, the commit
+`git rev-parse --short HEAD`). `latest` is a moving target — it does not tell you
+which binary version is running, which makes outage forensics and rollbacks
+hard (see the traffic-light RPC listener outage RCA).
+
+For reproducible, versioned deploys pin `tag` to the short-SHA tag instead:
+
+```yaml
+image:
+  registry: "ghcr.io/zako-ac"
+  tag: a1b2c3d
+  pullPolicy: IfNotPresent
+```
+
+Because the tag is immutable, the exact commit/version running is known, and
+rollback is just re-applying a previous tag. `latest` remains the dev default.
+
 ## nodeAffinity
 
 Node affinity rules can be set globally (applied to all pods) or overridden per service. The per-service value takes precedence over the global one; both empty means no constraint.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,5 +1,9 @@
 image:
   registry: ""
+  # Immutable tag is strongly preferred for reproducibility: docker-publish
+  # pushes a short-SHA tag (<commit sha>, e.g. "a1b2c3d") for every main build
+  # alongside "latest". Pin `tag` to that SHA so the deployed binary version is
+  # known and reproducible; "latest" makes rollbacks and version forensics hard.
   tag: latest
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What

Follow-up to the merged traffic-light RPC outage fix (#85, which covered §7 items 1·2·3·5). This PR adds the remaining **two recommended (§7) items**: resilient TL client stale-pool recovery and immutable image tags.

### 6. Resilient TL client (stale pooled-connection recovery) — `crates/tl-client/src/lib.rs`
The jsonrpsee `HttpClient` keeps an internal keep-alive connection pool. When the TL server restarts, a pooled connection goes stale and reusing it fails permanently (the same failure class as the taphub stall). Now:

- Every RPC call runs through `round_trip()`.
- On a **transport-level error** (`Transport` / `RestartNeeded` / `RequestTimeout` — the telltale of a stale pooled connection), we **rebuild the HttpClient (fresh pool) and retry once** — mirroring the `taphub-stall-recovery` pattern.
- Application-level (JSON-RPC call) errors are returned as-is and **never** retried.
- Also sets a **10s request timeout** (was jsonrpsee's 60s default) so a dead TL fails fast instead of stalling callers.
- Public API unchanged — `hq-core` and `zako3-audio-engine-controller` compile against it unchanged.

### 4. Immutable image tags — `helm/deployment.md`, `helm/values.yaml`
`docker-publish` already pushes a **short-SHA immutable tag** per `main` build alongside `latest`. Document pinning `image.tag` to that SHA so the deployed binary version is known and reproducible — `latest` was the blocker in the outage's forensics (couldn't tell which commit was running). Also documents the tag convention in `values.yaml`.

## Verified

- `cargo check` passes: `zako3-tl-client`, `hq-core`, `zako3-audio-engine-controller`.
- `cargo fmt --check` clean.
- Clippy warnings in tl-client are pre-existing (`too_many_arguments` in the unchanged `play`); the new `round_trip`/`build` code is clean.
- Full test-profile builds require a `cmake`/audiopus native toolchain that the sandbox prunes; the compile gate passes.

## Test plan

- After a TL restart, `TlClient` callers recover on the next call (client rebuilt, pool reset) instead of failing on a stale keep-alive connection.
- A dead TL surfaces as a fast (≤10s) transport error rather than a 60s hang.
- Helm deploys pin `image.tag` to a short-SHA tag for reproducible, versioned rollouts.
