### PR TITLE
fix: stall-free audio-engine track-end handling; pin stall-free protofish3 driver + pooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5977,7 +5977,6 @@ dependencies = [
 [[package]]
 name = "protofish3"
 version = "0.1.0"
-source = "git+https://github.com/zako-ac/protofish3-rs#7dd59333acc8d204bd2421fbdf11113faf4ef614"
 dependencies = [
  "bytes",
  "futures-util",
@@ -5993,7 +5992,6 @@ dependencies = [
 [[package]]
 name = "protofish3-proto"
 version = "0.1.0"
-source = "git+https://github.com/zako-ac/protofish3-rs#7dd59333acc8d204bd2421fbdf11113faf4ef614"
 dependencies = [
  "cookie-factory",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5977,6 +5977,7 @@ dependencies = [
 [[package]]
 name = "protofish3"
 version = "0.1.0"
+source = "git+https://github.com/zako-ac/protofish3-rs?rev=94f9f5dc6ed54028aa79c8455a931c24b6bfae50#94f9f5dc6ed54028aa79c8455a931c24b6bfae50"
 dependencies = [
  "bytes",
  "futures-util",
@@ -5992,6 +5993,7 @@ dependencies = [
 [[package]]
 name = "protofish3-proto"
 version = "0.1.0"
+source = "git+https://github.com/zako-ac/protofish3-rs?rev=94f9f5dc6ed54028aa79c8455a931c24b6bfae50#94f9f5dc6ed54028aa79c8455a931c24b6bfae50"
 dependencies = [
  "cookie-factory",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,9 @@ opt-level = 0
 
 [patch.crates-io.zod_gen]
 path = "vendor/zod_gen"
+
+[patch."https://github.com/zako-ac/protofish3-rs"]
+# Local patch of the protofish3 dependency carrying the stall-free driver fix and
+# ReconnectingClient pooling (see protofish3-rs branch fix/driver-stall-pooling).
+# In production this resolves to the pushed commit/branch rev instead of a path.
+protofish3 = { path = "/home/attacca/protofish3-rs/protofish3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ anyhow = "1.0"
 mockall = "0.12"
 jsonrpsee = { version = "0.24", features = ["full"] }
 songbird = { version = "0.5.0", git = "https://github.com/mincomk/songbird" }
-protofish3 = { git = "https://github.com/zako-ac/protofish3-rs" }
+protofish3 = { git = "https://github.com/zako-ac/protofish3-rs", rev = "94f9f5dc6ed54028aa79c8455a931c24b6bfae50" }
 async-nats = "0.45.0"
 dashmap = "6"
 envy = "0.4"
@@ -94,9 +94,3 @@ opt-level = 0
 
 [patch.crates-io.zod_gen]
 path = "vendor/zod_gen"
-
-[patch."https://github.com/zako-ac/protofish3-rs"]
-# Local patch of the protofish3 dependency carrying the stall-free driver fix and
-# ReconnectingClient pooling (see protofish3-rs branch fix/driver-stall-pooling).
-# In production this resolves to the pushed commit/branch rev instead of a path.
-protofish3 = { path = "/home/attacca/protofish3-rs/protofish3" }

--- a/crates/taphub-transport/client/src/lib.rs
+++ b/crates/taphub-transport/client/src/lib.rs
@@ -67,6 +67,7 @@ impl TransportClient {
             max_backoff: Duration::from_secs(5),
             backoff_multiplier: 2.0,
             max_retries: None,
+            pool_size: 1,
         };
 
         let mut conns = Vec::with_capacity(POOL_SIZE);

--- a/libs/zakofish/src/tap_pf3.rs
+++ b/libs/zakofish/src/tap_pf3.rs
@@ -68,6 +68,7 @@ impl ZakofishTapPf3 {
             max_backoff: Duration::from_secs(8),
             backoff_multiplier: 2.0,
             max_retries: None,
+            pool_size: 1,
         };
 
         // Build a resolver that queries 1.1.1.1 directly, bypassing the system

--- a/services/audio-engine/core/src/engine/session.rs
+++ b/services/audio-engine/core/src/engine/session.rs
@@ -299,7 +299,13 @@ impl SessionControl {
         metrics::record_track_lifecycle("skip", &normalize_queue_name(&queue_name));
 
         self.reconcile().await?;
-        self.preload_if_possible(next_track_id).await?;
+
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            if let Err(e) = this.preload_if_possible(next_track_id).await {
+                tracing::warn!(track_id = %next_track_id, error = %e, "Background preload failed");
+            }
+        });
 
         Ok(())
     }
@@ -549,10 +555,19 @@ pub fn create_session_control(
     let sc_clone = session_control.clone();
     tokio::spawn(async move {
         let mut end_rx = end_rx;
+        // Stall-free track-end handling: each ended track is handled in its own
+        // spawned task so a slow TTS/preload on one track can never block the
+        // handling of subsequent ended tracks (which previously serialized the
+        // whole loop behind a taphub call). Per-track work is safe to run
+        // concurrently: distinct track_ids touch distinct mixer/decoder slots,
+        // and any shared reconcile is still serialized by reconcile_guard.
         while let Some(track_id) = end_rx.recv().await {
-            if let Err(e) = sc_clone.handle_ended_track(track_id).await {
-                tracing::warn!(track_id = %track_id, error = %e, "Failed to handle ended track");
-            }
+            let sc = sc_clone.clone();
+            tokio::spawn(async move {
+                if let Err(e) = sc.handle_ended_track(track_id).await {
+                    tracing::warn!(track_id = %track_id, error = %e, "Failed to handle ended track");
+                }
+            });
         }
     });
 

--- a/services/audio-engine/core/src/engine/session.rs
+++ b/services/audio-engine/core/src/engine/session.rs
@@ -563,7 +563,10 @@ pub fn create_session_control(
         // and any shared reconcile is still serialized by reconcile_guard.
         while let Some(track_id) = end_rx.recv().await {
             let sc = sc_clone.clone();
+            let sc = sc_clone.clone();
+            let permit = end_sem.clone();
             tokio::spawn(async move {
+                let _permit = permit.acquire_owned().await;
                 if let Err(e) = sc.handle_ended_track(track_id).await {
                     tracing::warn!(track_id = %track_id, error = %e, "Failed to handle ended track");
                 }


### PR DESCRIPTION
## Summary
Fixes the recurring taphub stall at the code level. Root cause was in the `protofish3` connection driver (a single task serially awaiting every QUIC stream write — a wedged stream froze the whole connection, no keepalive, no recovery). Fixed upstream in protofish3-rs (#1) and pinned here.

## Changes
- **protofish3 (upstream #1, rev 94f9f5d)**: stall-free driver (per-stream writer tasks + 15s write timeout reset) + `ReconnectConfig::pool_size` pooling for `ReconnectingClient`. Pinned in `Cargo.toml`/`Cargo.lock`.
- **audio-engine session** (`services/audio-engine/core/src/engine/session.rs`): ended-track loop now handles each ended track in its own spawned task, so a slow TTS/preload on one track can no longer block handling of subsequent ended tracks; `next_music` preload moved to background. Guarded `reconcile()` stays synchronous (ordering) — its blocking is now bounded by the protofish3 per-write timeout.
- **ReconnectConfig callers** (`taphub-transport/client`, `zakofish/tap_pf3`): explicit `pool_size: 1` for the new field (preserves prior behaviour).

## Verification
- protofish3: full `cargo build` + `cargo test` pass (transfer/reconnect/pooling).
- zako3: `cargo metadata` resolves protofish3 to the pinned rev; edited Rust files parse-checked with rustfmt. Full zako3 `cargo check` not runnable in this env (no cmake for audiopus_sys; home disk ~99% full).

## Note
Merge ordering: protofish3-rs #1 (driver/pooling) should merge first; this PR pins its rev.